### PR TITLE
fix: replace deprecated Client#getVar calls

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.8.9'
+def runeLiteVersion = 'latest.release'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion

--- a/src/main/java/me/lucaspickering/HerbFarmCalculator.java
+++ b/src/main/java/me/lucaspickering/HerbFarmCalculator.java
@@ -125,7 +125,7 @@ public class HerbFarmCalculator {
      * variable based on the herb, player's farming level, and applicable yield
      * bonuses.
      *
-     * @see https://oldschool.runescape.wiki/w/Farming#Variable_crop_yield
+     * @see <a href="https://oldschool.runescape.wiki/w/Farming#Variable_crop_yield">Wiki Reference</a>
      * @param patch The patch being harvested
      * @return Odds of saving a live on each individual harvest, out of 1
      */
@@ -241,7 +241,7 @@ public class HerbFarmCalculator {
      * Get the cost of casting Resurrect Crops (assuming no staffs, since the
      * benefit of those is negligible).
      *
-     * @see https://oldschool.runescape.wiki/w/Resurrect_Crops
+     * @see <a href="https://oldschool.runescape.wiki/w/Resurrect_Crops">Wiki Reference</a>
      * @return Cost of all runes to cast Resurrect Crops
      */
     private int getResurrectRuneCost() {
@@ -256,7 +256,7 @@ public class HerbFarmCalculator {
      * Calculate the chance of the Resurrect Crops spell succeeding, based on
      * the player's magic level. Scales from 50% at level 78 to 75% at 99.
      *
-     * @see https://oldschool.runescape.wiki/w/Resurrect_Crops
+     * @see <a href="https://oldschool.runescape.wiki/w/Resurrect_Crops">Wiki Reference</a>
      * @return Chance of resurrection succeeding, out of 1
      */
     private double getResurrectionChance() {
@@ -284,7 +284,7 @@ public class HerbFarmCalculator {
     /**
      * Get the "chance to save" bonus due to equipped items.
      *
-     * @see https://oldschool.runescape.wiki/w/Farming#Variable_crop_yield
+     * @see <a href="https://oldschool.runescape.wiki/w/Farming#Variable_crop_yield">Wiki Reference</a>
      * @return Chance to save bonus, out of 1
      */
     private double getItemChanceToSaveBonus() {
@@ -304,7 +304,7 @@ public class HerbFarmCalculator {
      * Get the "chance to save" bonus due to achievement diary bonuses. These
      * bonuses are patch-specific.
      *
-     * @see https://oldschool.runescape.wiki/w/Farming#Variable_crop_yield
+     * @see <a href="https://oldschool.runescape.wiki/w/Farming#Variable_crop_yield">Wiki Reference</a>
      * @return Chance to save bonus, out of 1
      */
     private double getDiaryChanceToSaveBonus(HerbPatch patch) {
@@ -312,13 +312,13 @@ public class HerbFarmCalculator {
             case CATHERBY:
                 // +5% from medium, +10% from hard, +15% from elite
                 // https://oldschool.runescape.wiki/w/Kandarin_Diary
-                if (this.client.getVar(Varbits.DIARY_KANDARIN_ELITE) > 0) {
+                if (this.client.getVarbitValue(Varbits.DIARY_KANDARIN_ELITE) > 0) {
                     return 0.15;
                 }
-                if (this.client.getVar(Varbits.DIARY_KANDARIN_HARD) > 0) {
+                if (this.client.getVarbitValue(Varbits.DIARY_KANDARIN_HARD) > 0) {
                     return 0.10;
                 }
-                if (this.client.getVar(Varbits.DIARY_KANDARIN_MEDIUM) > 0) {
+                if (this.client.getVarbitValue(Varbits.DIARY_KANDARIN_MEDIUM) > 0) {
                     return 0.05;
                 }
                 return 0.0;
@@ -326,7 +326,7 @@ public class HerbFarmCalculator {
             // https://oldschool.runescape.wiki/w/Kourend_%26_Kebos_Diary#Rewards_3
             case FARMING_GUILD:
             case HOSIDIUS:
-                if (this.client.getVar(Varbits.DIARY_KOUREND_HARD) > 0) {
+                if (this.client.getVarbitValue(Varbits.DIARY_KOUREND_HARD) > 0) {
                     return 0.05;
                 }
                 return 0.0;
@@ -347,7 +347,7 @@ public class HerbFarmCalculator {
         switch (patch) {
             case FALADOR:
                 // +10% from medium
-                if (this.client.getVar(Varbits.DIARY_FALADOR_MEDIUM) > 0) {
+                if (this.client.getVarbitValue(Varbits.DIARY_FALADOR_MEDIUM) > 0) {
                     return 0.10;
                 }
                 return 0.0;

--- a/src/main/java/me/lucaspickering/utils/AnimaPlant.java
+++ b/src/main/java/me/lucaspickering/utils/AnimaPlant.java
@@ -24,7 +24,7 @@ public enum AnimaPlant {
      * Get the "chance to save" bonus provided by this plant. 5% for Attas, 0
      * for everything else.
      *
-     * @see https://oldschool.runescape.wiki/w/Farming#Variable_crop_yield
+     * @see <a href="https://oldschool.runescape.wiki/w/Farming#Variable_crop_yield">Wiki Reference</a>
      * @return Chance to save bonus, out of 1
      */
     public double getChanceToSaveBonus() {

--- a/src/main/java/me/lucaspickering/utils/Compost.java
+++ b/src/main/java/me/lucaspickering/utils/Compost.java
@@ -39,7 +39,7 @@ public enum Compost {
      * Get the number of "harvest lives" that a patch starts with when this
      * compost is applied.
      *
-     * @see https://oldschool.runescape.wiki/w/Farming#Variable_crop_yield
+     * @see <a href="https://oldschool.runescape.wiki/w/Farming#Variable_crop_yield">Wiki Reference</a>
      * @return Number of starting lives (default is 3)
      */
     public int getHarvestLives() {

--- a/src/main/java/me/lucaspickering/utils/Herb.java
+++ b/src/main/java/me/lucaspickering/utils/Herb.java
@@ -30,7 +30,7 @@ public enum Herb {
     private final int level;
     /**
      * The *minimum* "chance to save a life" for the herb, at level 1. Values from
-     * https://oldschool.runescape.wiki/w/Calculator:Farming/Herbs/Template?action=edit
+     * <a href="https://oldschool.runescape.wiki/w/Calculator:Farming/Herbs/Template?action=edit">Wiki</a>
      */
     private final double minChanceToSave;
     private final double plantXp;

--- a/src/main/java/me/lucaspickering/utils/HerbPatch.java
+++ b/src/main/java/me/lucaspickering/utils/HerbPatch.java
@@ -32,9 +32,9 @@ public enum HerbPatch {
             case WEISS:
                 return true;
             case HOSIDIUS:
-                // Values are THOUSANDTHS, not hundreths
+                // Values are THOUSANDTHS, not hundredths
                 // https://oldschool.runescape.wiki/w/Kourend_Favour#Hosidius_favour_rewards
-                return client.getVar(Varbits.KOUREND_FAVOR_HOSIDIUS) >= 500;
+                return client.getVarbitValue(Varbits.KOUREND_FAVOR_HOSIDIUS) >= 500;
             default:
                 return false;
         }


### PR DESCRIPTION
* Replaces `Client#getVar` calls with `Client#getVarbitValue` to resolve build errors on https://github.com/runelite/plugin-hub/pull/3975
* Fix malformed javadocs
