### PR TITLE
Added configurable sorting

### DIFF
--- a/src/main/java/me/lucaspickering/HerbFarmCalculator.java
+++ b/src/main/java/me/lucaspickering/HerbFarmCalculator.java
@@ -9,6 +9,7 @@ import me.lucaspickering.utils.SurvivalChance;
 import me.lucaspickering.utils.Utils;
 import me.lucaspickering.utils.HerbPatch;
 import me.lucaspickering.utils.HerbPatchBuffs;
+import me.lucaspickering.utils.SortingCriteria;
 import net.runelite.api.Client;
 import net.runelite.api.ItemID;
 import net.runelite.api.Skill;
@@ -52,7 +53,16 @@ public class HerbFarmCalculator {
                 .sorted(Comparator.comparing(patch -> patch.getPatch().getName()))
                 .collect(Collectors.toList());
 
+        // Sort according to criteria specified in the config
+        Comparator<HerbResult> criteria = this.config.criteria().getComparator();
+
+        // Sort in descending/Z->A order if enabled in the config
+        if (this.config.descending()){
+            criteria = criteria.reversed();
+        }
+
         List<HerbResult> herbs = Arrays.stream(Herb.values()).map(herb -> this.calculateHerb(herb, patches))
+                .sorted(criteria)
                 .collect(Collectors.toList());
         return new HerbCalculatorResult(this.getFarmingLevel(), patches, herbs);
     }

--- a/src/main/java/me/lucaspickering/HerbFarmCalculatorConfig.java
+++ b/src/main/java/me/lucaspickering/HerbFarmCalculatorConfig.java
@@ -6,9 +6,11 @@ import java.util.Set;
 import me.lucaspickering.utils.AnimaPlant;
 import me.lucaspickering.utils.Compost;
 import me.lucaspickering.utils.HerbPatch;
+import me.lucaspickering.utils.SortingCriteria;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.ConfigSection;
 
 @ConfigGroup("herbFarmCalculator")
 public interface HerbFarmCalculatorConfig extends Config {
@@ -50,4 +52,16 @@ public interface HerbFarmCalculatorConfig extends Config {
   default AnimaPlant animaPlant() {
     return AnimaPlant.NONE;
   }
+
+  @ConfigSection(name = "Sorting", description = "Configure the order in which herbs are displayed on the panel.", position = 8)
+  String sortingSection = "Sorting";
+
+  @ConfigItem(keyName = "criteria", name = "Criteria", description = "What criteria should the output be ordered by?", section = sortingSection)
+  default SortingCriteria criteria() {
+    return SortingCriteria.Level;
+  }
+
+  @ConfigItem(keyName = "descending", name = "Descending", description = "Sort in descending order? (Highest first/ Z->A)", section = sortingSection)
+  default boolean descending() {return false; }
+
 }

--- a/src/main/java/me/lucaspickering/utils/SortingCriteria.java
+++ b/src/main/java/me/lucaspickering/utils/SortingCriteria.java
@@ -1,0 +1,37 @@
+package me.lucaspickering.utils;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.Comparator;
+
+
+@AllArgsConstructor
+@Getter
+public enum SortingCriteria {
+    Alphabetical("Alphabetical"),
+    Level("Level"),
+    Profit("Profit"),
+    Yield("Yield"),
+    XP("XP");
+
+    public final String name;
+
+    public Comparator<HerbResult> getComparator(){
+        switch(this){
+            case Alphabetical:
+                return Comparator.comparing(herbResult -> herbResult.getHerb().getName());
+            case Level:
+                return Comparator.comparing(herbResult -> herbResult.getHerb().getLevel());
+            case Profit:
+                return Comparator.comparingDouble(HerbResult::getProfit);
+            case Yield:
+                return Comparator.comparingDouble(HerbResult::getExpectedYield);
+            case XP:
+                return Comparator.comparingDouble(HerbResult::getExpectedXp);
+        }
+        return Comparator.comparing(herbResult -> herbResult.getHerb().getLevel());
+    }
+
+
+
+}


### PR DESCRIPTION
Added sorting by alphabetical, level, profit, yield, or XP. Sorting is configurable to change criteria and ordering via a new section in the config panel.

**Added SortingCriteria.java:**

A public enum in utils that enumerates available sorting criteria. Public method getComparator defines the comparator used to achieve sorting. 

**Modified HerbFarmCalculatorConfig.java:**

Added a drop down list to select sorting criteria and a checkbox input boolean to switch ordering. Created a sorting section so that these options are listed together and separated from main plugin options.

**Modified HerbFarmCalculator.java:**

Changed the calculate function so that it fetches sorting options and applies sort to the list of HerbResults before returning a HerbCalculatorResult. 